### PR TITLE
fix Issue 18 - ocr_method has hardcoded tesseract path

### DIFF
--- a/app/app-config.json
+++ b/app/app-config.json
@@ -1,0 +1,5 @@
+{
+    "config": {
+        "tessaractPath": "C:\\Users\\bishi\\AppData\\Local\\Programs\\Tesseract-OCR\\tesseract.exe"
+    }
+}

--- a/app/ocr_method.py
+++ b/app/ocr_method.py
@@ -11,7 +11,10 @@ class VideoTextExtractor:
         self.difference_threshold = difference_threshold
         self.frame_diff_threshold = frame_diff_threshold
         self.threshold_value = threshold_value
-        pytesseract.pytesseract.tesseract_cmd = r'C:\Users\bishi\AppData\Local\Programs\Tesseract-OCR\tesseract.exe'
+
+        # Load App Json Config
+        app_config = self.load_app_json_config()
+        pytesseract.pytesseract.tesseract_cmd = app_config['config']['tessaractPath']
 
 
     def frame_difference(self, frame1, frame2):
@@ -183,6 +186,18 @@ class VideoTextExtractor:
         self.save_segments_to_json(segments)
         print(f"Text segments have been saved to {self.output_json_path}")
 
+    def load_app_json_config(self, path="app/app-config.json"):
+        """
+        Read App Json Config File
+        
+        Parameters: 
+            path(str) : path to JSON config file 
+        
+        Returns: (dict) JSON Loaded file
+        """        
+        with open(path, 'r') as file:
+            json_data = json.load(file)
+        return json_data
 
 if __name__ == "__main__":
     # Example usage


### PR DESCRIPTION
I've added a file called **app-config.json** inside the app folder to store fix the issue of hardcoded tessaract settings. It could be used to store other settings as I also added a function (**load_app_json_config()**)to read the JSON file which returns a dict that can be used within that class. 

![Screenshot 2024-06-13 at 1 15 07 AM](https://github.com/NM-TAFE/dip-programming-prj-advanced-gui-facilitate/assets/144990590/80f06270-f256-461f-be8d-42047d230c0d)
![Screenshot 2024-06-13 at 1 15 27 AM](https://github.com/NM-TAFE/dip-programming-prj-advanced-gui-facilitate/assets/144990590/b8c376ca-36c8-4a4c-810f-c81c46ca2730)
![Screenshot 2024-06-13 at 1 15 34 AM](https://github.com/NM-TAFE/dip-programming-prj-advanced-gui-facilitate/assets/144990590/3c343897-a062-4221-ae3c-db4cadbf739c)
