### PR TITLE
Fix #20: combine adjacent segments that do not contain text

### DIFF
--- a/app/ocr_method.py
+++ b/app/ocr_method.py
@@ -170,7 +170,7 @@ class VideoTextExtractor:
                                           current_segment["extracted_text"])  # Check reverse containment
                 is_within = current_segment["extracted_text"] in next_segment["extracted_text"]
 
-                if ratio_full >= 70 or ratio_within >= 80 or is_within:  # Adjust thresholds if needed (decrease for more leniance)
+                if ratio_full >= 70 or ratio_within >= 80 or is_within:  # Adjust thresholds if needed (decrease for more lenience)
                     # Combine segments
                     current_segment["end_frame"] = next_segment["end_frame"]
                     current_segment["end_time"] = next_segment["end_time"]

--- a/app/ocr_method.py
+++ b/app/ocr_method.py
@@ -146,6 +146,18 @@ class VideoTextExtractor:
         segments (list): A list of segments.
         output_path (str): The path to the output JSON file.
         """
+        self.combine_segments(segments)
+        with open(self.output_json_path, 'w') as f:
+            json.dump(segments, f, indent=4)
+
+    def combine_segments(self, segments):
+        """
+        Combine segments that are close to each other and contain the same
+        content.
+
+        Parameters:
+        segments (list): A list of segments.
+        """
         i = 0
         # Combine segments that are close to each other
         while i < len(segments) - 1:
@@ -154,23 +166,25 @@ class VideoTextExtractor:
             if current_segment["text_present"] and next_segment["text_present"]:
                 # Check if CURRENT segment's text is in the NEXT segment
                 ratio_full = fuzz.ratio(current_segment["extracted_text"], next_segment["extracted_text"])
-                ratio_within = fuzz.ratio(next_segment["extracted_text"], current_segment["extracted_text"])  # Check reverse containment
+                ratio_within = fuzz.ratio(next_segment["extracted_text"],
+                                          current_segment["extracted_text"])  # Check reverse containment
                 is_within = current_segment["extracted_text"] in next_segment["extracted_text"]
 
-                if ratio_full >= 70 or ratio_within >= 80 or is_within: # Adjust thresholds if needed (decrease for more leniance)
-                    # Combine segments 
+                if ratio_full >= 70 or ratio_within >= 80 or is_within:  # Adjust thresholds if needed (decrease for more leniance)
+                    # Combine segments
                     current_segment["end_frame"] = next_segment["end_frame"]
                     current_segment["end_time"] = next_segment["end_time"]
                     current_segment["extracted_text"] = next_segment["extracted_text"]  # Take the complete text
                     del segments[i + 1]
                 else:
                     i += 1
+            elif not current_segment["text_present"] and not next_segment["text_present"]:
+                current_segment["end_frame"] = next_segment["end_frame"]
+                current_segment["end_time"] = next_segment["end_time"]
+                del segments[i + 1]
             else:
                 i += 1
 
-        with open(self.output_json_path, 'w') as f:
-            json.dump(segments, f, indent=4)
-            
     def process_video(self):
         """
         Do the full video processing pipeline.

--- a/tests/ocr_method_test.py
+++ b/tests/ocr_method_test.py
@@ -1,0 +1,74 @@
+import unittest
+
+from app.ocr_method import VideoTextExtractor
+
+
+class CombineSegmentsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.text_extractor = VideoTextExtractor("example/test2 - 1716891852652.mp4",
+                                                 "test.json")
+        self.segments = [
+            {
+                "start_frame": 0,
+                "end_frame": 15,
+                "start_time": 0.0,
+                "end_time": 0.5,
+                "text_present": False,
+                "extracted_text": ""
+            },
+            {
+                "start_frame": 30,
+                "end_frame": 30,
+                "start_time": 1.0,
+                "end_time": 1.0,
+                "text_present": False,
+                "extracted_text": ""
+            },
+            {
+                "start_frame": 30,
+                "end_frame": 45,
+                "start_time": 1.0,
+                "end_time": 1.5,
+                "text_present": True,
+                "extracted_text": "Lorem Ipsum"
+            },
+            {
+                "start_frame": 45,
+                "end_frame": 480,
+                "start_time": 1.5,
+                "end_time": 16.0,
+                "text_present": True,
+                "extracted_text": "I finally saw The Matrix today.\nIt was the best documentary\nI've ever seen."
+            },
+            {
+                "start_frame": 480,
+                "end_frame": 510,
+                "start_time": 16.0,
+                "end_time": 17.0,
+                "text_present": True,
+                "extracted_text": "I finally saw The Matrix today.\nIt was the best documentary\nI've ever seen."
+            },
+        ]
+
+    def test_combine_segments_combines_segments_with_same_text(self):
+        self.text_extractor.combine_segments(self.segments)
+        combined_segment = self.segments[-1]
+
+        self.assertEqual(45, combined_segment["start_frame"])
+        self.assertEqual(510, combined_segment["end_frame"])
+
+    def test_combine_segments_combines_segments_without_text(self):
+        self.text_extractor.combine_segments(self.segments)
+        combined_segment = self.segments[0]
+
+        self.assertEqual(0, combined_segment["start_frame"])
+        self.assertEqual(30, combined_segment["end_frame"])
+
+    def test_combine_segments_does_not_combine_unrelated_segments(self):
+        self.text_extractor.combine_segments(self.segments)
+        unchanged_segment = self.segments[1]
+        self.assertEqual(30, unchanged_segment["start_frame"])
+        self.assertEqual(45, unchanged_segment["end_frame"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix #20 : Enhance video segment creation by combining adjacent segments when they both contain no text.

I split off the segment-combining code into a separate method so I could add unit tests to verify that the segments are combined correctly.